### PR TITLE
make location sorting screen respect profile restrictions

### DIFF
--- a/app/src/main/java/org/supla/android/data/source/local/LocationDao.java
+++ b/app/src/main/java/org/supla/android/data/source/local/LocationDao.java
@@ -90,11 +90,17 @@ public class LocationDao extends BaseDao {
               + " FROM " + SuplaContract.ChannelEntry.TABLE_NAME
               + " WHERE "                                                                           
               + SuplaContract.ChannelEntry.COLUMN_NAME_VISIBLE + " > 0 "
+              + " AND "
+              + SuplaContract.ChannelEntry.COLUMN_NAME_PROFILEID + " = "
+              + getCurrentProfileId()
             + " UNION "
               + "SELECT " + SuplaContract.ChannelGroupEntry.COLUMN_NAME_LOCATIONID
               + " FROM " + SuplaContract.ChannelGroupEntry.TABLE_NAME
               + " WHERE "
               + SuplaContract.ChannelGroupEntry.COLUMN_NAME_VISIBLE + " > 0"
+              + " AND "
+              + SuplaContract.ChannelGroupEntry.COLUMN_NAME_PROFILEID + " = "
+              + getCurrentProfileId()
             + ")"
             + " AND "
             + "L." + SuplaContract.LocationEntry.COLUMN_NAME_PROFILEID + " = "


### PR DESCRIPTION
Limit locations shown on sorting screen to locations available
for specific access id of given account.